### PR TITLE
Specify SYSTEM_NAMESPACE in KinD test

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,6 +16,7 @@ jobs:
       KO_DOCKER_REPO: registry:5000
       CAMEL_K_REGISTRY: registry:5000
       CAMEL_K_REGISTRY_INSECURE: true
+      SYSTEM_NAMESPACE: knative-sources
 
     steps:
       - name: Cleanup Host


### PR DESCRIPTION
I noticed the `system.Namespace()` panic in the update-deps PR, this should fix.

/assign @n3wscott 