### PR TITLE
Deprecate the CamelSource controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# Knative Eventing Camel Source
+# Deprecated: Knative Eventing Camel Source
+
+This repository will no longer be maintained and will be archived in a future release of Knative.
+
+Please visit the [Kamelet catalog at Apache](https://camel.apache.org/camel-kamelets/latest/) for an up-to-date collection of 
+Knative sources and sinks based on Apache Camel.
+
+Each entry of the catalog contains information on how to use it in a Knative environment, together with 
+general guides on prerequisite installation.
+
+Kamelets are also supported in the `kn` CLI through the [kn-source-kamelet](https://github.com/knative-sandbox/kn-plugin-source-kamelet) addon.
+
+---
 
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/knative-sandbox/eventing-camel)
 [![Go Report Card](https://goreportcard.com/badge/knative-sandbox/eventing-camel)](https://goreportcard.com/report/knative-sandbox/eventing-camel)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deprecated: Knative Eventing Camel Source
 
-This repository will no longer be maintained and will be archived in a future release of Knative.
+This repository will no longer be maintained and will be archived after the 0.23 release of Knative.
 
 Please visit the [Kamelet catalog at Apache](https://camel.apache.org/camel-kamelets/latest/) for an up-to-date collection of
 Knative sources and sinks based on Apache Camel.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This repository will no longer be maintained and will be archived in a future release of Knative.
 
-Please visit the [Kamelet catalog at Apache](https://camel.apache.org/camel-kamelets/latest/) for an up-to-date collection of 
+Please visit the [Kamelet catalog at Apache](https://camel.apache.org/camel-kamelets/latest/) for an up-to-date collection of
 Knative sources and sinks based on Apache Camel.
 
-Each entry of the catalog contains information on how to use it in a Knative environment, together with 
+Each entry of the catalog contains information on how to use it in a Knative environment, together with
 general guides on prerequisite installation.
 
 Kamelets are also supported in the `kn` CLI through the [kn-source-kamelet](https://github.com/knative-sandbox/kn-plugin-source-kamelet) addon.


### PR DESCRIPTION
This is not a stop in our contributions to Knative, we've just moved to a better model where users can pick [sources from a growing Catalog of Kamelets](https://camel.apache.org/camel-kamelets/latest/) and use them in Knative.

The [Camel K operator](https://github.com/apache/camel-k) can now use sink-binding to determine the configured destination, so the CamelSource controller contained in this repository is no longer necessary. 

The new [kn-source-kamelet](https://github.com/knative-sandbox/kn-plugin-source-kamelet) CLI plugin provides also a better user experience for Knative users that want to try Kamelets.

We can keep updating this repo for a few Knative releases, then it can be archived.

cc: @matzew , @christophd , @rhuss  , @grantr , @vaikas , @n3wscott , @mattmoor 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Knative CamelSources have been deprecated in favor of Kamelets
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
